### PR TITLE
Allow patching multiple repos in one project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the PATH is required for it to run.
 
   ```gradle
   plugins {
-      id 'ca.stellardrift.gitpatcher' version '2.0.0'
+      id 'ca.stellardrift.gitpatcher' version '1.1.0'
   }
   ```
 3. Configure gitpatcher:

--- a/README.md
+++ b/README.md
@@ -9,29 +9,35 @@ the PATH is required for it to run.
 
   ```gradle
   plugins {
-      id 'ca.stellardrift.gitpatcher' version '1.0.0'
+      id 'ca.stellardrift.gitpatcher' version '2.0.0'
   }
   ```
 3. Configure gitpatcher:
 
   ```gradle
-  patches {
-      // The submodule path you just created
-      submodule = 'upstream'
-      // The target folder for the patched repositories
-      target = file('target')
-      // The folder where the patches are saved
-      patches = file('patches')
+  gitPatcher.patchedRepos {
+      // 'repo' is arbitrary; it will be used for task names (see below section)
+      'repo' {
+          // The submodule path you just created
+          submodule = 'upstream'
+          // The target folder for the patched repositories
+          target = file('target')
+          // The folder where the patches are saved
+          patches = file('patches')
+      }
   }
   ```
 4. That's it! Now you can initialize your repository (see below) and start making commits to it. Then just make the patches and you can apply it to the target repository as often as you want.
 
 # Tasks
-| Name               | Description                                                                      |
-|--------------------|----------------------------------------------------------------------------------|
-| `updateSubmodules` | Initializes the submodule and updates it if it is outdated.                      |
-| `applyPatches`     | Initializes the target repository and applies the patches from the patch folder. |
-| `makePatches`      | Creates or updates the patches in the patch folder.                              |
+| Name                                | Description                                                                          |
+|-------------------------------------|--------------------------------------------------------------------------------------|
+| `update[CapitalizedName]Submodules` | Initializes the submodule and updates it if it is outdated.                          |
+| `apply[CapitalizedName]Patches`     | Initializes the target repository and applies the patches from the patch folder.     |
+| `make[CapitalizedName]Patches`      | Creates or updates the patches in the patch folder.                                  |
+| `updateSubmodules`                  | Lifecycle task which depends on all other `update[CapitalizedName]Submodules` tasks. |
+| `applyPatches`                      | Lifecycle task which depends on all other `apply[CapitalizedName]Patches` tasks.     |
+| `makePatches`                       | Lifecycle task which depends on all other `make[CapitalizedName]Patches` tasks.      |
 
 [example]: https://github.com/LapisBlue/Pore/tree/master/patches
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.1-SNAPSHOT
+version=2.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.0-SNAPSHOT
+version=1.1.0-SNAPSHOT

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
@@ -26,11 +26,42 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.provider.Property;
 
 public interface GitPatcherExtension {
+    /**
+     * Container holding the repos to patch.
+     *
+     * <p>Each {@link RepoPatchDetails} will
+     * have a {@code apply[CapitalizedName]Patches}, {@code make[CapitalizedName]Patches},
+     * and {@code update[CapitalizedName]Submodules} task.</p>
+     *
+     * <p>{@code applyPatches}, {@code rebuildPatches}, and {@code updateSubmodules}
+     * depend on the respective tasks of all registered repos.</p>
+     *
+     * @return repo container
+     * @since 2.0.0
+     */
     NamedDomainObjectContainer<RepoPatchDetails> getPatchedRepos();
 
+    /**
+     * Whether to add the patched repo to git's safe directories list.
+     *
+     * @return the add as safe directory property
+     * @since 2.0.0
+     */
     Property<Boolean> getAddAsSafeDirectory();
 
+    /**
+     * A temporary committer name to use for applied patches.
+     *
+     * @return the committer name property
+     * @since 2.0.0
+     */
     Property<String> getCommitterNameOverride();
 
+    /**
+     * A temporary committer name to use for applied patches.
+     *
+     * @return the committer name property
+     * @since 2.0.0
+     */
     Property<String> getCommitterEmailOverride();
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
@@ -22,65 +22,15 @@
  */
 package ca.stellardrift.gitpatcher;
 
-import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.provider.Property;
 
-public interface PatchExtension {
-    /**
-     * The root/project directory.
-     *
-     * <p>This usually does not need to be manually set.</p>
-     *
-     * @return the root
-     * @since 1.0.0
-     */
-    DirectoryProperty getRoot();
+public interface GitPatcherExtension {
+    NamedDomainObjectContainer<RepoPatchDetails> getPatchedRepos();
 
-    /**
-     * The name of the submodule directory created.
-     *
-     * @return the submodule
-     * @since 1.0.0
-     */
-    Property<String> getSubmodule();
-
-    /**
-     * The target folder for the patched repository.
-     *
-     * @return the target folder
-     * @since 1.0.0
-     */
-    DirectoryProperty getTarget();
-
-    /**
-     * The folder where the patches are saved
-     *
-     * @return the patch directory
-     * @since 1.0.0
-     */
-    DirectoryProperty getPatches();
-
-    /**
-     * Whether to add the patched repo to git's safe directories list.
-     *
-     * @return the add as safe directory property
-     * @since 1.0.0
-     */
     Property<Boolean> getAddAsSafeDirectory();
 
-    /**
-     * A temporary committer name to use for applied patches.
-     *
-     * @return the committer name property
-     * @since 1.0.0
-     */
     Property<String> getCommitterNameOverride();
 
-    /**
-     * A temporary committer name to use for applied patches.
-     *
-     * @return the committer name property
-     * @since 1.0.0
-     */
     Property<String> getCommitterEmailOverride();
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Stellardrift and contributors
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ca.stellardrift.gitpatcher;
+
+import javax.inject.Inject;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
+
+class GitPatcherExtensionImpl implements GitPatcherExtension {
+    private final NamedDomainObjectContainer<RepoPatchDetailsImpl> patchedRepos;
+    private final Property<Boolean> addAsSafeDirectory;
+    private final Property<String> committerNameOverride;
+    private final Property<String> committerEmailOverride;
+
+    @Inject
+    public GitPatcherExtensionImpl(final ObjectFactory objects, final ProviderFactory providers) {
+        this.patchedRepos = objects.domainObjectContainer(RepoPatchDetailsImpl.class);
+        this.addAsSafeDirectory = objects.property(Boolean.class)
+            .convention(
+                providers.environmentVariable("GITPATCHER_ADD_GIT_SAFEDIR")
+                    .map(it -> it.equals("true"))
+                    .orElse(false)
+            );
+        this.committerNameOverride = objects.property(String.class).convention("GitPatcher");
+        this.committerEmailOverride = objects.property(String.class).convention("gitpatcher@noreply");
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public NamedDomainObjectContainer<RepoPatchDetails> getPatchedRepos() {
+        return (NamedDomainObjectContainer) this.patchedRepos;
+    }
+
+    @Override
+    public Property<Boolean> getAddAsSafeDirectory() {
+        return this.addAsSafeDirectory;
+    }
+
+    @Override
+    public Property<String> getCommitterNameOverride() {
+        return this.committerNameOverride;
+    }
+
+    @Override
+    public Property<String> getCommitterEmailOverride() {
+        return this.committerEmailOverride;
+    }
+}

--- a/src/main/groovy/ca/stellardrift/gitpatcher/PatchExtension.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/PatchExtension.java
@@ -22,46 +22,84 @@
  */
 package ca.stellardrift.gitpatcher;
 
-import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 
-public interface GitPatcherExtension {
+/**
+ * @deprecated register a {@link RepoPatchDetails} to {@link GitPatcherExtension#getPatchedRepos()}
+ * instead, that is all this extension does now internally.
+ */
+@Deprecated
+public interface PatchExtension {
     /**
-     * Container holding the repos to patch.
+     * The root/project directory.
      *
-     * <p>Each {@link RepoPatchDetails} will
-     * have a {@code apply[CapitalizedName]Patches}, {@code make[CapitalizedName]Patches},
-     * and {@code update[CapitalizedName]Submodules} task.</p>
+     * <p>This usually does not need to be manually set.</p>
      *
-     * <p>{@code applyPatches}, {@code rebuildPatches}, and {@code updateSubmodules}
-     * depend on the respective tasks of all registered repos.</p>
-     *
-     * @return repo container
-     * @since 1.1.0
+     * @return the root
+     * @since 1.0.0
+     * @deprecated See {@link PatchExtension}
      */
-    NamedDomainObjectContainer<RepoPatchDetails> getPatchedRepos();
+    @Deprecated
+    DirectoryProperty getRoot();
+
+    /**
+     * The name of the submodule directory created.
+     *
+     * @return the submodule
+     * @since 1.0.0
+     * @deprecated See {@link PatchExtension}
+     */
+    @Deprecated
+    Property<String> getSubmodule();
+
+    /**
+     * The target folder for the patched repository.
+     *
+     * @return the target folder
+     * @since 1.0.0
+     * @deprecated See {@link PatchExtension}
+     */
+    @Deprecated
+    DirectoryProperty getTarget();
+
+    /**
+     * The folder where the patches are saved
+     *
+     * @return the patch directory
+     * @since 1.0.0
+     * @deprecated See {@link PatchExtension}
+     */
+    @Deprecated
+    DirectoryProperty getPatches();
 
     /**
      * Whether to add the patched repo to git's safe directories list.
      *
      * @return the add as safe directory property
-     * @since 1.1.0
+     * @since 1.0.0
+     * @deprecated See {@link PatchExtension}
      */
+    @Deprecated
     Property<Boolean> getAddAsSafeDirectory();
 
     /**
      * A temporary committer name to use for applied patches.
      *
      * @return the committer name property
-     * @since 1.1.0
+     * @since 1.0.0
+     * @deprecated See {@link PatchExtension}
      */
+    @Deprecated
     Property<String> getCommitterNameOverride();
 
     /**
      * A temporary committer name to use for applied patches.
      *
      * @return the committer name property
-     * @since 1.1.0
+     * @since 1.0.0
+     * @deprecated See {@link PatchExtension}
      */
+    @Deprecated
     Property<String> getCommitterEmailOverride();
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/PatchExtensionImpl.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/PatchExtensionImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015-2023, Stellardrift and contributors
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ca.stellardrift.gitpatcher;
+
+import javax.inject.Inject;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.Property;
+
+@Deprecated
+abstract class PatchExtensionImpl implements PatchExtension {
+    private final GitPatcherExtension ext;
+    private volatile RepoPatchDetails details = null;
+
+    @Inject
+    public PatchExtensionImpl(final GitPatcherExtension ext) {
+        this.ext = ext;
+    }
+
+    private RepoPatchDetails details() {
+        if (this.details == null) {
+            synchronized (this) {
+                if (this.details == null) {
+                    this.details = this.ext.getPatchedRepos().create("repo");
+                }
+            }
+        }
+        return this.details;
+    }
+
+    @Override
+    public DirectoryProperty getRoot() {
+        return this.details().getRoot();
+    }
+
+    @Override
+    public Property<String> getSubmodule() {
+        return this.details().getSubmodule();
+    }
+
+    @Override
+    public DirectoryProperty getTarget() {
+        return this.details().getTarget();
+    }
+
+    @Override
+    public DirectoryProperty getPatches() {
+        return this.details().getPatches();
+    }
+
+    @Override
+    public Property<Boolean> getAddAsSafeDirectory() {
+        return this.details().getAddAsSafeDirectory();
+    }
+
+    @Override
+    public Property<String> getCommitterNameOverride() {
+        return this.details().getCommitterNameOverride();
+    }
+
+    @Override
+    public Property<String> getCommitterEmailOverride() {
+        return this.details().getCommitterEmailOverride();
+    }
+}

--- a/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetails.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetails.java
@@ -39,7 +39,7 @@ public interface RepoPatchDetails {
      * <p>This usually does not need to be manually set.</p>
      *
      * @return the root
-     * @since 2.0.0
+     * @since 1.1.0
      */
     DirectoryProperty getRoot();
 
@@ -47,7 +47,7 @@ public interface RepoPatchDetails {
      * The name of the submodule directory created.
      *
      * @return the submodule
-     * @since 2.0.0
+     * @since 1.1.0
      */
     Property<String> getSubmodule();
 
@@ -55,7 +55,7 @@ public interface RepoPatchDetails {
      * The target folder for the patched repository.
      *
      * @return the target folder
-     * @since 2.0.0
+     * @since 1.1.0
      */
     DirectoryProperty getTarget();
 
@@ -63,7 +63,7 @@ public interface RepoPatchDetails {
      * The folder where the patches are saved
      *
      * @return the patch directory
-     * @since 2.0.0
+     * @since 1.1.0
      */
     DirectoryProperty getPatches();
 
@@ -71,7 +71,7 @@ public interface RepoPatchDetails {
      * Whether to add the patched repo to git's safe directories list.
      *
      * @return the add as safe directory property
-     * @since 2.0.0
+     * @since 1.1.0
      */
     Property<Boolean> getAddAsSafeDirectory();
 
@@ -79,7 +79,7 @@ public interface RepoPatchDetails {
      * A temporary committer name to use for applied patches.
      *
      * @return the committer name property
-     * @since 2.0.0
+     * @since 1.1.0
      */
     Property<String> getCommitterNameOverride();
 
@@ -87,7 +87,7 @@ public interface RepoPatchDetails {
      * A temporary committer name to use for applied patches.
      *
      * @return the committer name property
-     * @since 2.0.0
+     * @since 1.1.0
      */
     Property<String> getCommitterEmailOverride();
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetails.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetails.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, Stellardrift and contributors
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ca.stellardrift.gitpatcher;
+
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.Property;
+
+public interface RepoPatchDetails {
+    String getName();
+
+    /**
+     * The root/project directory.
+     *
+     * <p>This usually does not need to be manually set.</p>
+     *
+     * @return the root
+     * @since 2.0.0
+     */
+    DirectoryProperty getRoot();
+
+    /**
+     * The name of the submodule directory created.
+     *
+     * @return the submodule
+     * @since 2.0.0
+     */
+    Property<String> getSubmodule();
+
+    /**
+     * The target folder for the patched repository.
+     *
+     * @return the target folder
+     * @since 2.0.0
+     */
+    DirectoryProperty getTarget();
+
+    /**
+     * The folder where the patches are saved
+     *
+     * @return the patch directory
+     * @since 2.0.0
+     */
+    DirectoryProperty getPatches();
+
+    /**
+     * Whether to add the patched repo to git's safe directories list.
+     *
+     * @return the add as safe directory property
+     * @since 2.0.0
+     */
+    Property<Boolean> getAddAsSafeDirectory();
+
+    /**
+     * A temporary committer name to use for applied patches.
+     *
+     * @return the committer name property
+     * @since 2.0.0
+     */
+    Property<String> getCommitterNameOverride();
+
+    /**
+     * A temporary committer name to use for applied patches.
+     *
+     * @return the committer name property
+     * @since 2.0.0
+     */
+    Property<String> getCommitterEmailOverride();
+}

--- a/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetails.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetails.java
@@ -26,6 +26,11 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 
 public interface RepoPatchDetails {
+    /**
+     * Get the name of this {@link RepoPatchDetails}.
+     *
+     * @return the name
+     */
     String getName();
 
     /**

--- a/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetailsImpl.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/RepoPatchDetailsImpl.java
@@ -26,11 +26,11 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.ProviderFactory;
 
 import javax.inject.Inject;
 
-class PatchExtensionImpl implements PatchExtension {
+abstract class RepoPatchDetailsImpl implements RepoPatchDetails {
+    private final String name;
     private final DirectoryProperty root;
     private final Property<String> submodule;
     private final DirectoryProperty target;
@@ -41,19 +41,20 @@ class PatchExtensionImpl implements PatchExtension {
     private final Property<String> committerEmailOverride;
 
     @Inject
-    public PatchExtensionImpl(final ObjectFactory objects, final ProviderFactory providers, final ProjectLayout layout) {
+    public RepoPatchDetailsImpl(final String name, final ObjectFactory objects, final ProjectLayout layout) {
+        this.name = name;
         this.root = objects.directoryProperty().convention(layout.getProjectDirectory());
         this.submodule = objects.property(String.class);
         this.target = objects.directoryProperty();
         this.patches = objects.directoryProperty();
-        this.addAsSafeDirectory = objects.property(Boolean.class)
-            .convention(
-                providers.environmentVariable("GITPATCHER_ADD_GIT_SAFEDIR")
-                    .map(it -> it.equals("true"))
-                    .orElse(false)
-            );
-        this.committerNameOverride = objects.property(String.class).convention("GitPatcher");
-        this.committerEmailOverride = objects.property(String.class).convention("gitpatcher@noreply");
+        this.addAsSafeDirectory = objects.property(Boolean.class);
+        this.committerNameOverride = objects.property(String.class);
+        this.committerEmailOverride = objects.property(String.class);
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
     }
 
     @Override

--- a/src/main/groovy/ca/stellardrift/gitpatcher/task/FindGitTask.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/task/FindGitTask.groovy
@@ -24,21 +24,16 @@ package ca.stellardrift.gitpatcher.task
 
 import ca.stellardrift.gitpatcher.Git
 import org.gradle.api.DefaultTask
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 abstract class FindGitTask extends DefaultTask {
-
-    @Input
-    abstract Property<String> getSubmodule()
 
     @TaskAction
     void findGit() {
         def git = new Git(project.rootDir)
         try {
             def version = git.version().text.readLines().join(', ')
-            logger.lifecycle("Using $version for patching submodule ${submodule.get()}.")
+            logger.lifecycle("Using $version for patching submodules.")
         } catch (Throwable e) {
             throw new UnsupportedOperationException(
                     'Failed to verify Git version. Make sure running the Gradle build in an environment where Git is in your PATH.', e);


### PR DESCRIPTION
example usage:
```groovy
gitPatcher.patchedRepos {
    'snakeyaml' {
        submodule = "snakeyaml-upstream"
        target = file("snakeyaml")
        patches = file("snakeyaml-patches")
    }
    'typesafeConfig' {
        submodule = "typesafe-config-upstream"
        target = file("typesafe-config")
        patches = file("typesafe-config-patches")
    }
}
```