### PR TITLE
feat: add ability to apply extra arguments to Git am

### DIFF
--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2023, Stellardrift and contributors
+ * Copyright (c) 2015-2024, Stellardrift and contributors
  * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
@@ -67,6 +67,7 @@ class GitPatcher implements Plugin<Project> {
                 rootUpdate.configure { dependsOn(updateSubmodules) }
 
                 def apply = tasks.register('apply' + capitalizedName  +'Patches', ApplyPatchesTask) {
+                    setExtension(this.extension)
                     group = GITPATCHER_TASK_GROUP
                     /*, dependsOn: 'updateSubmodules' We don't want to update the submodule if we're targeting a specific commit */
                 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
@@ -67,7 +67,10 @@ class GitPatcher implements Plugin<Project> {
                 rootUpdate.configure { dependsOn(updateSubmodules) }
 
                 def apply = tasks.register('apply' + capitalizedName  +'Patches', ApplyPatchesTask) {
-                    setExtension(this.extension)
+                    def finalArg = new ArrayList<String>()
+                    finalArg.addAll(this.extension.applyExtraArguments.get())
+                    finalArg.addAll(getApplyExtraArguments())
+                    setApplyExtraArguments(finalArg)
                     group = GITPATCHER_TASK_GROUP
                     /*, dependsOn: 'updateSubmodules' We don't want to update the submodule if we're targeting a specific commit */
                 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
@@ -69,7 +69,6 @@ class GitPatcher implements Plugin<Project> {
                 def apply = tasks.register('apply' + capitalizedName  +'Patches', ApplyPatchesTask) {
                     def finalArg = new ArrayList<String>()
                     finalArg.addAll(this.extension.applyExtraArguments.get())
-                    finalArg.addAll(getApplyExtraArguments())
                     setApplyExtraArguments(finalArg)
                     group = GITPATCHER_TASK_GROUP
                     /*, dependsOn: 'updateSubmodules' We don't want to update the submodule if we're targeting a specific commit */

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
@@ -69,7 +69,7 @@ class GitPatcher implements Plugin<Project> {
                 def apply = tasks.register('apply' + capitalizedName  +'Patches', ApplyPatchesTask) {
                     def finalArg = new ArrayList<String>()
                     finalArg.addAll(this.extension.applyExtraArguments.get())
-                    setApplyExtraArguments(finalArg)
+                    it.setApplyExtraArguments(finalArg)
                     group = GITPATCHER_TASK_GROUP
                     /*, dependsOn: 'updateSubmodules' We don't want to update the submodule if we're targeting a specific commit */
                 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcher.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2024, Stellardrift and contributors
+ * Copyright (c) 2015-2025, Stellardrift and contributors
  * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
@@ -23,6 +23,7 @@
 package ca.stellardrift.gitpatcher;
 
 import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 public interface GitPatcherExtension {
@@ -64,4 +65,12 @@ public interface GitPatcherExtension {
      * @since 1.1.0
      */
     Property<String> getCommitterEmailOverride();
+
+    /**
+     * The extra command line arguments which will be passed to Git am command
+     * when applying patches.
+     *
+     * @return the extra arguments which will be passed to Git am command
+     */
+    ListProperty<String> getAMExtraArguments();
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
@@ -72,5 +72,5 @@ public interface GitPatcherExtension {
      *
      * @return the extra arguments which will be passed to Git am command
      */
-    ListProperty<String> getAMExtraArguments();
+    ListProperty<String> getApplyExtraArguments();
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Stellardrift and contributors
+ * Copyright (c) 2023-2024, Stellardrift and contributors
  * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Stellardrift and contributors
+ * Copyright (c) 2023-2025, Stellardrift and contributors
  * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
@@ -25,14 +25,18 @@ package ca.stellardrift.gitpatcher;
 import javax.inject.Inject;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
+
+import java.util.Collections;
 
 class GitPatcherExtensionImpl implements GitPatcherExtension {
     private final NamedDomainObjectContainer<RepoPatchDetailsImpl> patchedRepos;
     private final Property<Boolean> addAsSafeDirectory;
     private final Property<String> committerNameOverride;
     private final Property<String> committerEmailOverride;
+    private final ListProperty<String> amExtraArguments;
 
     @Inject
     public GitPatcherExtensionImpl(final ObjectFactory objects, final ProviderFactory providers) {
@@ -45,6 +49,7 @@ class GitPatcherExtensionImpl implements GitPatcherExtension {
             );
         this.committerNameOverride = objects.property(String.class).convention("GitPatcher");
         this.committerEmailOverride = objects.property(String.class).convention("gitpatcher@noreply");
+        this.amExtraArguments = objects.listProperty(String.class).convention(Collections.emptyList());
     }
 
     @Override
@@ -66,5 +71,10 @@ class GitPatcherExtensionImpl implements GitPatcherExtension {
     @Override
     public Property<String> getCommitterEmailOverride() {
         return this.committerEmailOverride;
+    }
+
+    @Override
+    public ListProperty<String> getAMExtraArguments() {
+        return this.amExtraArguments;
     }
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Stellardrift and contributors
+ * Copyright (c) 2023-2024, Stellardrift and contributors
  * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
@@ -36,7 +36,7 @@ class GitPatcherExtensionImpl implements GitPatcherExtension {
     private final Property<Boolean> addAsSafeDirectory;
     private final Property<String> committerNameOverride;
     private final Property<String> committerEmailOverride;
-    private final ListProperty<String> amExtraArguments;
+    private final ListProperty<String> applyExtraArguments;
 
     @Inject
     public GitPatcherExtensionImpl(final ObjectFactory objects, final ProviderFactory providers) {
@@ -49,7 +49,7 @@ class GitPatcherExtensionImpl implements GitPatcherExtension {
             );
         this.committerNameOverride = objects.property(String.class).convention("GitPatcher");
         this.committerEmailOverride = objects.property(String.class).convention("gitpatcher@noreply");
-        this.amExtraArguments = objects.listProperty(String.class).convention(Collections.emptyList());
+        this.applyExtraArguments = objects.listProperty(String.class);
     }
 
     @Override
@@ -74,7 +74,7 @@ class GitPatcherExtensionImpl implements GitPatcherExtension {
     }
 
     @Override
-    public ListProperty<String> getAMExtraArguments() {
-        return this.amExtraArguments;
+    public ListProperty<String> getApplyExtraArguments() {
+        return this.applyExtraArguments;
     }
 }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/GitPatcherExtensionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Stellardrift and contributors
+ * Copyright (c) 2023-2025, Stellardrift and contributors
  * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/groovy/ca/stellardrift/gitpatcher/task/patch/ApplyPatchesTask.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/task/patch/ApplyPatchesTask.groovy
@@ -37,6 +37,7 @@ import static java.lang.System.out
 @UntrackedTask(because = "State is tracked by git")
 abstract class ApplyPatchesTask extends PatchTask {
     @Option
+    @Internal
     List<String> applyExtraArguments
 
     @Internal

--- a/src/main/groovy/ca/stellardrift/gitpatcher/task/patch/ApplyPatchesTask.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/task/patch/ApplyPatchesTask.groovy
@@ -22,10 +22,14 @@
  */
 package ca.stellardrift.gitpatcher.task.patch
 
+import ca.stellardrift.gitpatcher.GitPatcherExtension
 import groovy.io.FileType
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.jetbrains.annotations.ApiStatus
+
+import javax.inject.Inject
 
 import static java.lang.System.out
 
@@ -40,6 +44,12 @@ import org.gradle.api.tasks.UntrackedTask
 
 @UntrackedTask(because = "State is tracked by git")
 abstract class ApplyPatchesTask extends PatchTask {
+    private GitPatcherExtension ext
+
+    @ApiStatus.Internal
+    void setExtension(GitPatcherExtension ext) {
+        this.ext = ext
+    }
 
     @Internal
     UpdateSubmodulesTask updateTask
@@ -127,7 +137,7 @@ abstract class ApplyPatchesTask extends PatchTask {
                 logger.lifecycle 'Applying patches from {} to {}', patchDir.get().asFile, repoFile
 
                 git.am('--abort') >>> null
-                git.am('--3way', *patches.collect { it.absolutePath }) >> out
+                git.am('--3way', *ext.AMExtraArguments.get(), *patches.collect { it.absolutePath }) >> out
 
                 logger.lifecycle 'Successfully applied patches from {} to {}', patchDir.get().asFile, repoFile
             }

--- a/src/main/groovy/ca/stellardrift/gitpatcher/task/patch/ApplyPatchesTask.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/task/patch/ApplyPatchesTask.groovy
@@ -22,34 +22,22 @@
  */
 package ca.stellardrift.gitpatcher.task.patch
 
+import ca.stellardrift.gitpatcher.Git
+import ca.stellardrift.gitpatcher.task.UpdateSubmodulesTask
 import ca.stellardrift.gitpatcher.GitPatcherExtension
 import groovy.io.FileType
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.jetbrains.annotations.ApiStatus
-
-import javax.inject.Inject
+import org.gradle.api.tasks.*
+import org.gradle.api.tasks.options.Option
 
 import static java.lang.System.out
 
-import ca.stellardrift.gitpatcher.Git
-import ca.stellardrift.gitpatcher.task.UpdateSubmodulesTask
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.UntrackedTask
-
 @UntrackedTask(because = "State is tracked by git")
 abstract class ApplyPatchesTask extends PatchTask {
-    private GitPatcherExtension ext
-
-    @ApiStatus.Internal
-    void setExtension(GitPatcherExtension ext) {
-        this.ext = ext
-    }
+    @Option
+    List<String> applyExtraArguments
 
     @Internal
     UpdateSubmodulesTask updateTask
@@ -137,7 +125,7 @@ abstract class ApplyPatchesTask extends PatchTask {
                 logger.lifecycle 'Applying patches from {} to {}', patchDir.get().asFile, repoFile
 
                 git.am('--abort') >>> null
-                git.am('--3way', *ext.AMExtraArguments.get(), *patches.collect { it.absolutePath }) >> out
+                git.am('--3way', *applyExtraArguments, *patches.collect { it.absolutePath }) >> out
 
                 logger.lifecycle 'Successfully applied patches from {} to {}', patchDir.get().asFile, repoFile
             }


### PR DESCRIPTION
This PR adds "getAMExtraArguments" method to the plugin extension.
The added "am extra arguments" property is used to pass more specific command line option to the Git am command.

For example, this plugin can't apply the patch generated by it because misconfiguration of the final Git am command. After doing some research on it, I finally found this: https://stackoverflow.com/a/63148678 . By following it, I finally found that '--ignore-space-change' is needed to solve that. (It is said that CRLF is also a possible reason for this issue, but '--keep-cr' does not necessary for me)

Why not just adding '--ignore-space-change'? I didn't really know why, maybe someone else need to add other options? Or '--ignore-space-change' is not necessary for others?

Looking forward to reviews :)