### PR TITLE
Fix rebuild not working

### DIFF
--- a/src/main/groovy/ca/stellardrift/gitpatcher/task/FindGitTask.groovy
+++ b/src/main/groovy/ca/stellardrift/gitpatcher/task/FindGitTask.groovy
@@ -25,12 +25,14 @@ package ca.stellardrift.gitpatcher.task
 import ca.stellardrift.gitpatcher.Git
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "Always check for Git in the environment when requested")
 abstract class FindGitTask extends DefaultTask {
 
-    @Input
+    @Internal
     protected abstract DirectoryProperty getRootDir();
 
     FindGitTask() {


### PR DESCRIPTION
`@Input` on a directory property fails the build, and I don't think we really want to track the project dir as an input